### PR TITLE
CMake: find exact python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ endif ()
 # Developer may want to specify some variable to find proper version.
 # ~~~
 # Priority is as same order as follows:
-#   1. `Python_LOOKUP_VERSION`: specify minimum version to find.
+#   1. `Python_LOOKUP_VERSION`: specify major.minor version to find.
 #   2. 'Python_FIND_VIRTUALENV': specify 'ONLY' to use virtualenv activated.
 #   3. `Python_ROOT`: specify installed location.
 #   4. If nothing specified, use default behavior.
@@ -190,7 +190,7 @@ endif ()
 include(FeatureSummary)
 if (Python_LOOKUP_VERSION)
   set(Python_FIND_STRATEGY VERSION)
-  find_package(Python ${Python_LOOKUP_VERSION} COMPONENTS Interpreter Development NumPy)
+  find_package(Python ${Python_LOOKUP_VERSION} EXACT COMPONENTS Interpreter Development NumPy)
 else ()
   set(Python_FIND_STRATEGY LOCATION)
   find_package(Python COMPONENTS Interpreter Development NumPy)


### PR DESCRIPTION
When there are multiple versions of python on development environment, we need to specify an exact python version.
CMake try to find highest version(ex. 3.10) in default.

This modification allows to specify exact python major.minor such as 3.8.

