### PR TITLE
Add OGRCurvePolygon::isRingCorrectType

### DIFF
--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -2479,8 +2479,10 @@ class CPL_DLL OGRCurvePolygon CPL_NON_FINAL : public OGRSurface
   private:
     OGRBoolean IntersectsPoint(const OGRPoint *p) const;
     OGRBoolean ContainsPoint(const OGRPoint *p) const;
-    virtual bool checkRing(const OGRCurve *poNewRing,
-                           bool bOnlyType = false) const;
+
+    virtual bool isRingCorrectType(const OGRCurve *poRing) const;
+
+    virtual bool checkRing(const OGRCurve *poNewRing) const;
     OGRErr addRingDirectlyInternal(OGRCurve *poCurve, int bNeedRealloc);
     static OGRErr addCurveDirectlyFromWkt(OGRGeometry *poSelf,
                                           OGRCurve *poCurve);
@@ -2696,8 +2698,9 @@ class CPL_DLL OGRPolygon CPL_NON_FINAL : public OGRCurvePolygon
     friend class OGRPolyhedralSurface;
     friend class OGRTriangulatedSurface;
 
-    virtual bool checkRing(const OGRCurve *poNewRing,
-                           bool bOnlyType = false) const override;
+    virtual bool isRingCorrectType(const OGRCurve *poRing) const override;
+
+    virtual bool checkRing(const OGRCurve *poNewRing) const override;
     virtual OGRErr importFromWKTListOnly(const char **ppszInput, int bHasZ,
                                          int bHasM, OGRRawPoint *&paoPoints,
                                          int &nMaxPoints, double *&padfZ);

--- a/ogr/ogrcurvepolygon.cpp
+++ b/ogr/ogrcurvepolygon.cpp
@@ -75,7 +75,7 @@ OGRCurvePolygon &OGRCurvePolygon::operator=(const OGRCurvePolygon &other)
 
         for (const auto *poRing : other.oCC)
         {
-            if (!checkRing(poRing, /* bOnlyType = */ true))
+            if (!isRingCorrectType(poRing))
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Illegal use of OGRCurvePolygon::operator=(): "
@@ -348,12 +348,26 @@ OGRErr OGRCurvePolygon::addRing(const OGRCurve *poNewRing)
 }
 
 /************************************************************************/
+/*                            isRingCorrectType()                       */
+/************************************************************************/
+bool OGRCurvePolygon::isRingCorrectType(const OGRCurve *poRing) const
+{
+    return poRing && !EQUAL(poRing->getGeometryName(), "LINEARRING");
+}
+
+/************************************************************************/
 /*                            checkRing()                               */
 /************************************************************************/
 
-bool OGRCurvePolygon::checkRing(const OGRCurve *poNewRing, bool bOnlyType) const
+bool OGRCurvePolygon::checkRing(const OGRCurve *poNewRing) const
 {
-    if (!bOnlyType && !poNewRing->IsEmpty() && !poNewRing->get_IsClosed())
+    if (!isRingCorrectType(poNewRing))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Linearring not allowed.");
+        return false;
+    }
+
+    if (!poNewRing->IsEmpty() && !poNewRing->get_IsClosed())
     {
         // This configuration option name must be the same as in
         // OGRPolygon::checkRing()
@@ -377,14 +391,8 @@ bool OGRCurvePolygon::checkRing(const OGRCurve *poNewRing, bool bOnlyType) const
 
     if (wkbFlatten(poNewRing->getGeometryType()) == wkbLineString)
     {
-        if (!bOnlyType && poNewRing->getNumPoints() < 4)
+        if (poNewRing->getNumPoints() < 4)
         {
-            return false;
-        }
-
-        if (EQUAL(poNewRing->getGeometryName(), "LINEARRING"))
-        {
-            CPLError(CE_Failure, CPLE_AppDefined, "Linearring not allowed.");
             return false;
         }
     }

--- a/ogr/ogrpolygon.cpp
+++ b/ogr/ogrpolygon.cpp
@@ -263,21 +263,29 @@ OGRLinearRing *OGRPolygon::stealInteriorRing(int iRing)
 }
 
 /*! @cond Doxygen_Suppress */
+
+/************************************************************************/
+/*                            isRingCorrectType()                               */
+/************************************************************************/
+bool OGRPolygon::isRingCorrectType(const OGRCurve *poRing) const
+{
+    return poRing != nullptr && EQUAL(poRing->getGeometryName(), "LINEARRING");
+}
+
 /************************************************************************/
 /*                            checkRing()                               */
 /************************************************************************/
 
-bool OGRPolygon::checkRing(const OGRCurve *poNewRing, bool bOnlyType) const
+bool OGRPolygon::checkRing(const OGRCurve *poNewRing) const
 {
-    if (poNewRing == nullptr ||
-        !(EQUAL(poNewRing->getGeometryName(), "LINEARRING")))
+    if (!isRingCorrectType(poNewRing))
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Wrong curve type. Expected LINEARRING.");
         return false;
     }
 
-    if (!bOnlyType && !poNewRing->IsEmpty() && !poNewRing->get_IsClosed())
+    if (!poNewRing->IsEmpty() && !poNewRing->get_IsClosed())
     {
         // This configuration option name must be the same as in
         // OGRCurvePolygon::checkRing()


### PR DESCRIPTION
For me this is a little more clear than the `bOnlyType` flag -- I had to read the implementations to understand what that flag was doing.

Feel free to keep or discard as you like. (Tests could probably be kept regardless)

Unrelated, but it seems odd that `CurvePolygon` will not accept a `LinearRing` ring.