### PR TITLE
gdal_typetraits: remove some boilerplate

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(
   test_gdal_dted.cpp
   test_gdal_gtiff.cpp
   test_gdal_pixelfn.cpp
+  test_gdal_typetraits.cpp
   test_ogr.cpp
   test_ogr_organize_polygons.cpp
   test_ogr_geometry_stealing.cpp

--- a/autotest/cpp/test_gdal_typetraits.cpp
+++ b/autotest/cpp/test_gdal_typetraits.cpp
@@ -21,26 +21,32 @@ TEST_F(test_gdal_typetraits, CXXTypeTraits)
     EXPECT_EQ(
         gdal::CXXTypeTraits<int8_t>::GetExtendedDataType().GetNumericDataType(),
         GDT_Int8);
+
     static_assert(gdal::CXXTypeTraits<uint8_t>::gdal_type == GDT_Byte);
     static_assert(gdal::CXXTypeTraits<uint8_t>::size == 1);
     EXPECT_EQ(gdal::CXXTypeTraits<uint8_t>::GetExtendedDataType()
                   .GetNumericDataType(),
               GDT_Byte);
+
     static_assert(gdal::CXXTypeTraits<int16_t>::gdal_type == GDT_Int16);
     static_assert(gdal::CXXTypeTraits<int16_t>::size == 2);
     EXPECT_EQ(gdal::CXXTypeTraits<int16_t>::GetExtendedDataType()
                   .GetNumericDataType(),
               GDT_Int16);
+
     static_assert(gdal::CXXTypeTraits<uint16_t>::gdal_type == GDT_UInt16);
     static_assert(gdal::CXXTypeTraits<uint16_t>::size == 2);
     EXPECT_EQ(gdal::CXXTypeTraits<uint16_t>::GetExtendedDataType()
                   .GetNumericDataType(),
               GDT_UInt16);
+
     static_assert(gdal::CXXTypeTraits<int32_t>::gdal_type == GDT_Int32);
     static_assert(gdal::CXXTypeTraits<int32_t>::size == 4);
     EXPECT_EQ(gdal::CXXTypeTraits<int32_t>::GetExtendedDataType()
                   .GetNumericDataType(),
               GDT_Int32);
+    static_assert(gdal::CXXTypeTraits<int32_t>::ogr_type == OFTInteger);
+
     static_assert(gdal::CXXTypeTraits<uint32_t>::gdal_type == GDT_UInt32);
     static_assert(gdal::CXXTypeTraits<uint32_t>::size == 4);
     EXPECT_EQ(gdal::CXXTypeTraits<uint32_t>::GetExtendedDataType()

--- a/autotest/cpp/test_gdal_typetraits.cpp
+++ b/autotest/cpp/test_gdal_typetraits.cpp
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2024, Even Rouault <even.rouault at spatialys.com>
+
+#include "gdal_unit_test.h"
+
+#include "gdal_typetraits.h"
+
+#include "gtest_include.h"
+
+namespace
+{
+
+struct test_gdal_typetraits : public ::testing::Test
+{
+};
+
+TEST_F(test_gdal_typetraits, CXXTypeTraits)
+{
+    static_assert(gdal::CXXTypeTraits<int8_t>::gdal_type == GDT_Int8);
+    static_assert(gdal::CXXTypeTraits<int8_t>::size == 1);
+    EXPECT_EQ(
+        gdal::CXXTypeTraits<int8_t>::GetExtendedDataType().GetNumericDataType(),
+        GDT_Int8);
+    static_assert(gdal::CXXTypeTraits<uint8_t>::gdal_type == GDT_Byte);
+    static_assert(gdal::CXXTypeTraits<uint8_t>::size == 1);
+    EXPECT_EQ(gdal::CXXTypeTraits<uint8_t>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Byte);
+    static_assert(gdal::CXXTypeTraits<int16_t>::gdal_type == GDT_Int16);
+    static_assert(gdal::CXXTypeTraits<int16_t>::size == 2);
+    EXPECT_EQ(gdal::CXXTypeTraits<int16_t>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Int16);
+    static_assert(gdal::CXXTypeTraits<uint16_t>::gdal_type == GDT_UInt16);
+    static_assert(gdal::CXXTypeTraits<uint16_t>::size == 2);
+    EXPECT_EQ(gdal::CXXTypeTraits<uint16_t>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_UInt16);
+    static_assert(gdal::CXXTypeTraits<int32_t>::gdal_type == GDT_Int32);
+    static_assert(gdal::CXXTypeTraits<int32_t>::size == 4);
+    EXPECT_EQ(gdal::CXXTypeTraits<int32_t>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Int32);
+    static_assert(gdal::CXXTypeTraits<uint32_t>::gdal_type == GDT_UInt32);
+    static_assert(gdal::CXXTypeTraits<uint32_t>::size == 4);
+    EXPECT_EQ(gdal::CXXTypeTraits<uint32_t>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_UInt32);
+    static_assert(gdal::CXXTypeTraits<int64_t>::gdal_type == GDT_Int64);
+    static_assert(gdal::CXXTypeTraits<int64_t>::size == 8);
+    EXPECT_EQ(gdal::CXXTypeTraits<int64_t>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Int64);
+    static_assert(gdal::CXXTypeTraits<uint64_t>::gdal_type == GDT_UInt64);
+    static_assert(gdal::CXXTypeTraits<uint64_t>::size == 8);
+    EXPECT_EQ(gdal::CXXTypeTraits<uint64_t>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_UInt64);
+    static_assert(gdal::CXXTypeTraits<float>::gdal_type == GDT_Float32);
+    static_assert(gdal::CXXTypeTraits<float>::size == 4);
+    EXPECT_EQ(
+        gdal::CXXTypeTraits<float>::GetExtendedDataType().GetNumericDataType(),
+        GDT_Float32);
+    static_assert(gdal::CXXTypeTraits<double>::gdal_type == GDT_Float64);
+    static_assert(gdal::CXXTypeTraits<double>::size == 8);
+    EXPECT_EQ(
+        gdal::CXXTypeTraits<double>::GetExtendedDataType().GetNumericDataType(),
+        GDT_Float64);
+    static_assert(gdal::CXXTypeTraits<std::complex<float>>::gdal_type ==
+                  GDT_CFloat32);
+    static_assert(gdal::CXXTypeTraits<std::complex<float>>::size == 8);
+    EXPECT_EQ(gdal::CXXTypeTraits<std::complex<float>>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_CFloat32);
+    static_assert(gdal::CXXTypeTraits<std::complex<double>>::gdal_type ==
+                  GDT_CFloat64);
+    static_assert(gdal::CXXTypeTraits<std::complex<double>>::size == 16);
+    EXPECT_EQ(gdal::CXXTypeTraits<std::complex<double>>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_CFloat64);
+    static_assert(gdal::CXXTypeTraits<std::string>::size == 0);
+    EXPECT_EQ(
+        gdal::CXXTypeTraits<std::string>::GetExtendedDataType().GetClass(),
+        GEDTC_STRING);
+}
+
+TEST_F(test_gdal_typetraits, GDALDataTypeTraits)
+{
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_Byte>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Byte);
+    static_assert(
+        std::is_same_v<gdal::GDALDataTypeTraits<GDT_Byte>::type, uint8_t>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_Byte>::size == 1);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_Int8>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Int8);
+    static_assert(
+        std::is_same_v<gdal::GDALDataTypeTraits<GDT_Int8>::type, int8_t>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_Int8>::size == 1);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_Int16>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Int16);
+    static_assert(
+        std::is_same_v<gdal::GDALDataTypeTraits<GDT_Int16>::type, int16_t>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_Int16>::size == 2);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_UInt16>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_UInt16);
+    static_assert(
+        std::is_same_v<gdal::GDALDataTypeTraits<GDT_UInt16>::type, uint16_t>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_UInt16>::size == 2);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_Int32>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Int32);
+    static_assert(
+        std::is_same_v<gdal::GDALDataTypeTraits<GDT_Int32>::type, int32_t>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_Int32>::size == 4);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_UInt32>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_UInt32);
+    static_assert(
+        std::is_same_v<gdal::GDALDataTypeTraits<GDT_UInt32>::type, uint32_t>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_UInt32>::size == 4);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_Int64>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Int64);
+    static_assert(
+        std::is_same_v<gdal::GDALDataTypeTraits<GDT_Int64>::type, int64_t>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_Int64>::size == 8);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_UInt64>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_UInt64);
+    static_assert(
+        std::is_same_v<gdal::GDALDataTypeTraits<GDT_UInt64>::type, uint64_t>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_UInt64>::size == 8);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_Float32>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Float32);
+    static_assert(
+        std::is_same_v<gdal::GDALDataTypeTraits<GDT_Float32>::type, float>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_Float32>::size == 4);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_Float64>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_Float64);
+    static_assert(
+        std::is_same_v<gdal::GDALDataTypeTraits<GDT_Float64>::type, double>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_Float64>::size == 8);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_CInt16>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_CInt16);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_CInt32>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_CInt32);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_CFloat32>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_CFloat32);
+    static_assert(std::is_same_v<gdal::GDALDataTypeTraits<GDT_CFloat32>::type,
+                                 std::complex<float>>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_CFloat32>::size == 8);
+    EXPECT_EQ(gdal::GDALDataTypeTraits<GDT_CFloat64>::GetExtendedDataType()
+                  .GetNumericDataType(),
+              GDT_CFloat64);
+    static_assert(std::is_same_v<gdal::GDALDataTypeTraits<GDT_CFloat64>::type,
+                                 std::complex<double>>);
+    static_assert(gdal::GDALDataTypeTraits<GDT_CFloat64>::size == 16);
+}
+
+TEST_F(test_gdal_typetraits, GetOGRFieldType)
+{
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_Byte), OFTInteger);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_Int8), OFTInteger);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_Int16), OFTInteger);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_Int32), OFTInteger);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_UInt16), OFTInteger);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_UInt32), OFTInteger64);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_Int64), OFTInteger64);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_UInt64), OFTReal);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_Float32), OFTReal);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_Float64), OFTReal);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_CInt16), OFTMaxType);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_CInt32), OFTMaxType);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_CFloat32), OFTMaxType);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_CFloat64), OFTMaxType);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_Unknown), OFTMaxType);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDT_TypeCount), OFTMaxType);
+
+    EXPECT_EQ(gdal::GetOGRFieldType(GDALExtendedDataType::Create(GDT_Byte)),
+              OFTInteger);
+    EXPECT_EQ(gdal::GetOGRFieldType(GDALExtendedDataType::CreateString()),
+              OFTString);
+    EXPECT_EQ(
+        gdal::GetOGRFieldType(GDALExtendedDataType::Create("compound", 0, {})),
+        OFTMaxType);
+}
+
+}  // namespace

--- a/gcore/CMakeLists.txt
+++ b/gcore/CMakeLists.txt
@@ -194,6 +194,7 @@ target_public_header(
   gdalgeorefpamdataset.h
   gdal_mdreader.h
   gdalsubdatasetinfo.h
+  gdal_typetraits.h
 )
 
 set(GDAL_DATA_FILES

--- a/gcore/gdal_typetraits.h
+++ b/gcore/gdal_typetraits.h
@@ -1,0 +1,510 @@
+/******************************************************************************
+ * Name:     gdal_typetraits.h
+ * Project:  GDAL Core
+ * Purpose:  Type traits for mapping C++ types to and from GDAL/OGR types.
+ * Author:   Robin Princeley, <rprinceley at esri dot com>
+ *
+ ******************************************************************************
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+#if !defined(GDAL_TYPETRAITS_H_INCLUDED)
+#define GDAL_TYPETRAITS_H_INCLUDED
+
+#include "gdal_priv.h"
+
+// NOTE: below GDAL_ENABLE_FLOAT16 is not guaranteed to be stable and is
+// mostly for Esri internal needs for now. Might be revisited if/once RFC 100
+// (https://github.com/OSGeo/gdal/pull/10146) is adopted.
+#ifdef GDAL_ENABLE_FLOAT16
+#if defined(__GNUC__) || defined(__clang__)
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
+#include <float.h>  // Also brings in _Float16
+#endif
+#endif
+
+#include <complex>
+
+namespace gdal
+{
+
+/** Trait accepting a C++ type ([u]int[8/16/32/64], float, double,
+ * std::complex<float>, std::complex<double> or std::string)
+ * and mapping it to GDALDataType / OGRFieldType.
+ *
+ * Each specialization has the following members:
+ * static constexpr GDALDataType gdal_type;
+ * static constexpr size_t size;
+ * static constexpr OGRFieldType ogr_type;
+ * static constexpr OGRFieldSubType ogr_subtype;
+ *
+ * @since 3.11
+ */
+template <typename T> struct CXXTypeTraits
+{
+};
+
+//! @cond Doxygen_Suppress
+template <> struct CXXTypeTraits<int8_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_Int8;
+    static constexpr size_t size = sizeof(int8_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Int8);
+    }
+};
+
+template <> struct CXXTypeTraits<uint8_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_Byte;
+    static constexpr size_t size = sizeof(uint8_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Byte);
+    }
+};
+
+template <> struct CXXTypeTraits<int16_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_Int16;
+    static constexpr size_t size = sizeof(int16_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTInt16;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Int16);
+    }
+};
+
+template <> struct CXXTypeTraits<uint16_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_UInt16;
+    static constexpr size_t size = sizeof(uint16_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_UInt16);
+    }
+};
+
+template <> struct CXXTypeTraits<int32_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_Int32;
+    static constexpr size_t size = sizeof(int32_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Int32);
+    }
+};
+
+template <> struct CXXTypeTraits<uint32_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_UInt32;
+    static constexpr size_t size = sizeof(uint32_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger64;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_UInt32);
+    }
+};
+
+template <> struct CXXTypeTraits<int64_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_Int64;
+    static constexpr size_t size = sizeof(int64_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger64;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Int64);
+    }
+};
+
+template <> struct CXXTypeTraits<uint64_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_UInt64;
+    static constexpr size_t size = sizeof(uint64_t);
+    // Mapping to Real is questionable...
+    static constexpr OGRFieldType ogr_type = OFTReal;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_UInt64);
+    }
+};
+
+template <> struct CXXTypeTraits<float>
+{
+    static constexpr GDALDataType gdal_type = GDT_Float32;
+    static constexpr size_t size = sizeof(float);
+    static constexpr OGRFieldType ogr_type = OFTReal;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTFloat32;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Float32);
+    }
+};
+
+template <> struct CXXTypeTraits<double>
+{
+    static constexpr GDALDataType gdal_type = GDT_Float64;
+    static constexpr size_t size = sizeof(double);
+    static constexpr OGRFieldType ogr_type = OFTReal;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Float64);
+    }
+};
+
+template <> struct CXXTypeTraits<std::complex<float>>
+{
+    static constexpr GDALDataType gdal_type = GDT_CFloat32;
+    static constexpr size_t size = sizeof(float) * 2;
+    static constexpr OGRFieldType ogr_type = OFTMaxType;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_CFloat32);
+    }
+};
+
+template <> struct CXXTypeTraits<std::complex<double>>
+{
+    static constexpr GDALDataType gdal_type = GDT_CFloat64;
+    static constexpr size_t size = sizeof(double) * 2;
+    static constexpr OGRFieldType ogr_type = OFTMaxType;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_CFloat64);
+    }
+};
+
+#if defined(GDAL_ENABLE_FLOAT16) && defined(FLT16_MAX) && defined(FLT16_MIN)
+template <> struct CXXTypeTraits<_Float16>
+{
+    static constexpr GDALDataType gdal_type = GDT_Float16;
+    static constexpr size_t size = sizeof(_Float16);
+    static constexpr OGRFieldType ogr_type = OFTReal;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Float16);
+    }
+};
+#endif
+
+template <> struct CXXTypeTraits<std::string>
+{
+    static constexpr GDALDataType gdal_type = GDT_Unknown;
+    static constexpr size_t size = 0;
+    static constexpr OGRFieldType ogr_type = OFTString;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::CreateString();
+    }
+};
+
+//! @endcond
+
+/** Trait accepting a GDALDataType and mapping it to corresponding C++ type and
+ * OGRFieldType
+ *
+ * Each specialization has the following members:
+ * typedef T type; (except for GDT_CInt16 and GDT_CInt32)
+ * static constexpr size_t size;
+ * static constexpr OGRFieldType ogr_type;
+ * static constexpr OGRFieldSubType ogr_subtype;
+ * static inline GDALExtendedDataType GetExtendedDataType();
+ *
+ * @since 3.11
+ */
+template <GDALDataType T> struct GDALDataTypeTraits
+{
+};
+
+//! @cond Doxygen_Suppress
+template <> struct GDALDataTypeTraits<GDT_Int8>
+{
+    typedef int8_t type;
+    static constexpr size_t size = sizeof(int8_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Int8);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_Byte>
+{
+    typedef uint8_t type;
+    static constexpr size_t size = sizeof(uint8_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Byte);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_Int16>
+{
+    typedef int16_t type;
+    static constexpr size_t size = sizeof(int16_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTInt16;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Int16);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_UInt16>
+{
+    typedef uint16_t type;
+    static constexpr size_t size = sizeof(uint16_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_UInt16);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_Int32>
+{
+    typedef int32_t type;
+    static constexpr size_t size = sizeof(int32_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Int32);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_UInt32>
+{
+    typedef uint32_t type;
+    static constexpr size_t size = sizeof(uint32_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger64;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_UInt32);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_Int64>
+{
+    typedef int64_t type;
+    static constexpr size_t size = sizeof(int64_t);
+    static constexpr OGRFieldType ogr_type = OFTInteger64;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Int64);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_UInt64>
+{
+    typedef uint64_t type;
+    static constexpr size_t size = sizeof(uint64_t);
+    // Mapping to Real is questionable...
+    static constexpr OGRFieldType ogr_type = OFTReal;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_UInt64);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_Float32>
+{
+    typedef float type;
+    static constexpr size_t size = sizeof(float);
+    static constexpr OGRFieldType ogr_type = OFTReal;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTFloat32;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Float32);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_Float64>
+{
+    typedef double type;
+    static constexpr size_t size = sizeof(double);
+    static constexpr OGRFieldType ogr_type = OFTReal;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_Float64);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_CInt16>
+{
+    // typedef type not available !
+    static constexpr size_t size = sizeof(int16_t) * 2;
+    static constexpr OGRFieldType ogr_type = OFTMaxType;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_CInt16);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_CInt32>
+{
+    // typedef type not available !
+    static constexpr size_t size = sizeof(int32_t) * 2;
+    static constexpr OGRFieldType ogr_type = OFTMaxType;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_CInt32);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_CFloat32>
+{
+    typedef std::complex<float> type;
+    static constexpr size_t size = sizeof(float) * 2;
+    static constexpr OGRFieldType ogr_type = OFTMaxType;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_CFloat32);
+    }
+};
+
+template <> struct GDALDataTypeTraits<GDT_CFloat64>
+{
+    typedef std::complex<double> type;
+    static constexpr size_t size = sizeof(double) * 2;
+    static constexpr OGRFieldType ogr_type = OFTMaxType;
+    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(GDT_CFloat64);
+    }
+};
+
+//! @endcond
+
+/** Map a GDALDataType to the most suitable OGRFieldType.
+ *
+ * Note that GDT_UInt32 is mapped to OFTInteger64 to avoid data losses.
+ * GDT_UInt64 is mapped to OFTReal, which can be lossy. If values are
+ * guaranteed to be in [0, INT64_MAX] range, callers might want to use
+ * OFTInteger64 instead.
+ * There is no mapping for complex data types.
+ *
+ * @since 3.11
+ */
+inline OGRFieldType GetOGRFieldType(const GDALDataType gdal_type)
+{
+    switch (gdal_type)
+    {
+        case GDT_Byte:
+        case GDT_Int8:
+        case GDT_Int16:
+        case GDT_Int32:
+        case GDT_UInt16:
+            return OFTInteger;
+        case GDT_UInt32:
+        case GDT_Int64:
+            return OFTInteger64;
+        case GDT_UInt64:  // Questionable
+        case GDT_Float32:
+        case GDT_Float64:
+            return OFTReal;
+        case GDT_CInt16:
+        case GDT_CInt32:
+        case GDT_CFloat32:
+        case GDT_CFloat64:
+        case GDT_Unknown:
+        case GDT_TypeCount:
+            break;
+    }
+    return OFTMaxType;
+}
+
+/** Map a GDALExtendedDataType to the most suitable OGRFieldType.
+ *
+ * Note that GDT_UInt32 is mapped to OFTInteger64 to avoid data losses.
+ * GDT_UInt64 is mapped to OFTReal, which can be lossy. If values are
+ * guaranteed to be in [0, INT64_MAX] range, callers might want to use
+ * OFTInteger64 instead.
+ *
+ * @since 3.11
+ */
+inline OGRFieldType GetOGRFieldType(const GDALExtendedDataType &oEDT)
+{
+    if (oEDT.GetClass() == GEDTC_NUMERIC)
+        return GetOGRFieldType(oEDT.GetNumericDataType());
+    else if (oEDT.GetClass() == GEDTC_STRING)
+        return OFTString;
+    return OFTMaxType;
+}
+
+}  // namespace gdal
+
+#endif  // GDAL_TYPETRAITS_H_INCLUDED

--- a/gcore/gdal_typetraits.h
+++ b/gcore/gdal_typetraits.h
@@ -43,412 +43,6 @@
 namespace gdal
 {
 
-/** Trait accepting a C++ type ([u]int[8/16/32/64], float, double,
- * std::complex<float>, std::complex<double> or std::string)
- * and mapping it to GDALDataType / OGRFieldType.
- *
- * Each specialization has the following members:
- * static constexpr GDALDataType gdal_type;
- * static constexpr size_t size;
- * static constexpr OGRFieldType ogr_type;
- * static constexpr OGRFieldSubType ogr_subtype;
- *
- * @since 3.11
- */
-template <typename T> struct CXXTypeTraits
-{
-};
-
-//! @cond Doxygen_Suppress
-template <> struct CXXTypeTraits<int8_t>
-{
-    static constexpr GDALDataType gdal_type = GDT_Int8;
-    static constexpr size_t size = sizeof(int8_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Int8);
-    }
-};
-
-template <> struct CXXTypeTraits<uint8_t>
-{
-    static constexpr GDALDataType gdal_type = GDT_Byte;
-    static constexpr size_t size = sizeof(uint8_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Byte);
-    }
-};
-
-template <> struct CXXTypeTraits<int16_t>
-{
-    static constexpr GDALDataType gdal_type = GDT_Int16;
-    static constexpr size_t size = sizeof(int16_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTInt16;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Int16);
-    }
-};
-
-template <> struct CXXTypeTraits<uint16_t>
-{
-    static constexpr GDALDataType gdal_type = GDT_UInt16;
-    static constexpr size_t size = sizeof(uint16_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_UInt16);
-    }
-};
-
-template <> struct CXXTypeTraits<int32_t>
-{
-    static constexpr GDALDataType gdal_type = GDT_Int32;
-    static constexpr size_t size = sizeof(int32_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Int32);
-    }
-};
-
-template <> struct CXXTypeTraits<uint32_t>
-{
-    static constexpr GDALDataType gdal_type = GDT_UInt32;
-    static constexpr size_t size = sizeof(uint32_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger64;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_UInt32);
-    }
-};
-
-template <> struct CXXTypeTraits<int64_t>
-{
-    static constexpr GDALDataType gdal_type = GDT_Int64;
-    static constexpr size_t size = sizeof(int64_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger64;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Int64);
-    }
-};
-
-template <> struct CXXTypeTraits<uint64_t>
-{
-    static constexpr GDALDataType gdal_type = GDT_UInt64;
-    static constexpr size_t size = sizeof(uint64_t);
-    // Mapping to Real is questionable...
-    static constexpr OGRFieldType ogr_type = OFTReal;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_UInt64);
-    }
-};
-
-template <> struct CXXTypeTraits<float>
-{
-    static constexpr GDALDataType gdal_type = GDT_Float32;
-    static constexpr size_t size = sizeof(float);
-    static constexpr OGRFieldType ogr_type = OFTReal;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTFloat32;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Float32);
-    }
-};
-
-template <> struct CXXTypeTraits<double>
-{
-    static constexpr GDALDataType gdal_type = GDT_Float64;
-    static constexpr size_t size = sizeof(double);
-    static constexpr OGRFieldType ogr_type = OFTReal;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Float64);
-    }
-};
-
-template <> struct CXXTypeTraits<std::complex<float>>
-{
-    static constexpr GDALDataType gdal_type = GDT_CFloat32;
-    static constexpr size_t size = sizeof(float) * 2;
-    static constexpr OGRFieldType ogr_type = OFTMaxType;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_CFloat32);
-    }
-};
-
-template <> struct CXXTypeTraits<std::complex<double>>
-{
-    static constexpr GDALDataType gdal_type = GDT_CFloat64;
-    static constexpr size_t size = sizeof(double) * 2;
-    static constexpr OGRFieldType ogr_type = OFTMaxType;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_CFloat64);
-    }
-};
-
-#if defined(GDAL_ENABLE_FLOAT16) && defined(FLT16_MAX) && defined(FLT16_MIN)
-template <> struct CXXTypeTraits<_Float16>
-{
-    static constexpr GDALDataType gdal_type = GDT_Float16;
-    static constexpr size_t size = sizeof(_Float16);
-    static constexpr OGRFieldType ogr_type = OFTReal;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Float16);
-    }
-};
-#endif
-
-template <> struct CXXTypeTraits<std::string>
-{
-    static constexpr GDALDataType gdal_type = GDT_Unknown;
-    static constexpr size_t size = 0;
-    static constexpr OGRFieldType ogr_type = OFTString;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::CreateString();
-    }
-};
-
-//! @endcond
-
-/** Trait accepting a GDALDataType and mapping it to corresponding C++ type and
- * OGRFieldType
- *
- * Each specialization has the following members:
- * typedef T type; (except for GDT_CInt16 and GDT_CInt32)
- * static constexpr size_t size;
- * static constexpr OGRFieldType ogr_type;
- * static constexpr OGRFieldSubType ogr_subtype;
- * static inline GDALExtendedDataType GetExtendedDataType();
- *
- * @since 3.11
- */
-template <GDALDataType T> struct GDALDataTypeTraits
-{
-};
-
-//! @cond Doxygen_Suppress
-template <> struct GDALDataTypeTraits<GDT_Int8>
-{
-    typedef int8_t type;
-    static constexpr size_t size = sizeof(int8_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Int8);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_Byte>
-{
-    typedef uint8_t type;
-    static constexpr size_t size = sizeof(uint8_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Byte);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_Int16>
-{
-    typedef int16_t type;
-    static constexpr size_t size = sizeof(int16_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTInt16;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Int16);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_UInt16>
-{
-    typedef uint16_t type;
-    static constexpr size_t size = sizeof(uint16_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_UInt16);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_Int32>
-{
-    typedef int32_t type;
-    static constexpr size_t size = sizeof(int32_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Int32);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_UInt32>
-{
-    typedef uint32_t type;
-    static constexpr size_t size = sizeof(uint32_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger64;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_UInt32);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_Int64>
-{
-    typedef int64_t type;
-    static constexpr size_t size = sizeof(int64_t);
-    static constexpr OGRFieldType ogr_type = OFTInteger64;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Int64);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_UInt64>
-{
-    typedef uint64_t type;
-    static constexpr size_t size = sizeof(uint64_t);
-    // Mapping to Real is questionable...
-    static constexpr OGRFieldType ogr_type = OFTReal;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_UInt64);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_Float32>
-{
-    typedef float type;
-    static constexpr size_t size = sizeof(float);
-    static constexpr OGRFieldType ogr_type = OFTReal;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTFloat32;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Float32);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_Float64>
-{
-    typedef double type;
-    static constexpr size_t size = sizeof(double);
-    static constexpr OGRFieldType ogr_type = OFTReal;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_Float64);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_CInt16>
-{
-    // typedef type not available !
-    static constexpr size_t size = sizeof(int16_t) * 2;
-    static constexpr OGRFieldType ogr_type = OFTMaxType;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_CInt16);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_CInt32>
-{
-    // typedef type not available !
-    static constexpr size_t size = sizeof(int32_t) * 2;
-    static constexpr OGRFieldType ogr_type = OFTMaxType;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_CInt32);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_CFloat32>
-{
-    typedef std::complex<float> type;
-    static constexpr size_t size = sizeof(float) * 2;
-    static constexpr OGRFieldType ogr_type = OFTMaxType;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_CFloat32);
-    }
-};
-
-template <> struct GDALDataTypeTraits<GDT_CFloat64>
-{
-    typedef std::complex<double> type;
-    static constexpr size_t size = sizeof(double) * 2;
-    static constexpr OGRFieldType ogr_type = OFTMaxType;
-    static constexpr OGRFieldSubType ogr_subtype = OFSTNone;
-
-    static inline GDALExtendedDataType GetExtendedDataType()
-    {
-        return GDALExtendedDataType::Create(GDT_CFloat64);
-    }
-};
-
-//! @endcond
-
 /** Map a GDALDataType to the most suitable OGRFieldType.
  *
  * Note that GDT_UInt32 is mapped to OFTInteger64 to avoid data losses.
@@ -459,7 +53,7 @@ template <> struct GDALDataTypeTraits<GDT_CFloat64>
  *
  * @since 3.11
  */
-inline OGRFieldType GetOGRFieldType(const GDALDataType gdal_type)
+constexpr inline OGRFieldType GetOGRFieldType(const GDALDataType gdal_type)
 {
     switch (gdal_type)
     {
@@ -486,6 +80,317 @@ inline OGRFieldType GetOGRFieldType(const GDALDataType gdal_type)
     }
     return OFTMaxType;
 }
+
+/** Map a GDALDataType to the most suitable OGRFieldSubType.
+ *
+ * @since 3.11
+ */
+constexpr inline OGRFieldSubType
+GetOGRFieldSubType(const GDALDataType gdal_type)
+{
+    switch (gdal_type)
+    {
+        case GDT_Byte:
+            break;
+        case GDT_Int8:
+            break;
+        case GDT_Int16:
+            return OFSTInt16;
+        case GDT_Int32:
+            break;
+        case GDT_UInt16:
+            break;
+        case GDT_UInt32:
+            break;
+        case GDT_Int64:
+            break;
+        case GDT_UInt64:
+            break;
+        case GDT_Float32:
+            return OFSTFloat32;
+        case GDT_Float64:
+            break;
+        case GDT_CInt16:
+            break;
+        case GDT_CInt32:
+            break;
+        case GDT_CFloat32:
+            break;
+        case GDT_CFloat64:
+            break;
+        case GDT_Unknown:
+            break;
+        case GDT_TypeCount:
+            break;
+    }
+    return OFSTNone;
+}
+
+/** Trait accepting a C++ type ([u]int[8/16/32/64], float, double,
+ * std::complex<float>, std::complex<double> or std::string)
+ * and mapping it to GDALDataType / OGRFieldType.
+ *
+ * Each specialization has the following members:
+ * static constexpr GDALDataType gdal_type;
+ * static constexpr size_t size;
+ * static constexpr OGRFieldType ogr_type;
+ * static constexpr OGRFieldSubType ogr_subtype;
+ *
+ * @since 3.11
+ */
+template <typename T> struct CXXTypeTraits
+{
+};
+
+namespace detail
+{
+template <typename T> struct CXXTypeTraitsBase
+{
+    static constexpr GDALDataType gdal_type = GDT_Unknown;
+    static constexpr size_t size = sizeof(T);
+    static constexpr OGRFieldType ogr_type =
+        GetOGRFieldType(CXXTypeTraits<T>::gdal_type);
+    static constexpr OGRFieldSubType ogr_subtype =
+        GetOGRFieldSubType(CXXTypeTraits<T>::gdal_type);
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(CXXTypeTraits<T>::gdal_type);
+    }
+};
+}  // namespace detail
+
+//! @cond Doxygen_Suppress
+template <>
+struct CXXTypeTraits<int8_t> : public detail::CXXTypeTraitsBase<int8_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_Int8;
+};
+
+template <>
+struct CXXTypeTraits<uint8_t> : public detail::CXXTypeTraitsBase<uint8_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_Byte;
+};
+
+template <>
+struct CXXTypeTraits<int16_t> : public detail::CXXTypeTraitsBase<int16_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_Int16;
+};
+
+template <>
+struct CXXTypeTraits<uint16_t> : public detail::CXXTypeTraitsBase<uint16_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_UInt16;
+};
+
+template <>
+struct CXXTypeTraits<int32_t> : public detail::CXXTypeTraitsBase<int32_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_Int32;
+};
+
+template <>
+struct CXXTypeTraits<uint32_t> : public detail::CXXTypeTraitsBase<uint32_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_UInt32;
+};
+
+template <>
+struct CXXTypeTraits<int64_t> : public detail::CXXTypeTraitsBase<int64_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_Int64;
+};
+
+template <>
+struct CXXTypeTraits<uint64_t> : public detail::CXXTypeTraitsBase<uint64_t>
+{
+    static constexpr GDALDataType gdal_type = GDT_UInt64;
+};
+
+template <>
+struct CXXTypeTraits<float> : public detail::CXXTypeTraitsBase<float>
+{
+    static constexpr GDALDataType gdal_type = GDT_Float32;
+};
+
+template <>
+struct CXXTypeTraits<double> : public detail::CXXTypeTraitsBase<double>
+{
+    static constexpr GDALDataType gdal_type = GDT_Float64;
+};
+
+template <>
+struct CXXTypeTraits<std::complex<float>>
+    : public detail::CXXTypeTraitsBase<std::complex<float>>
+{
+    static constexpr GDALDataType gdal_type = GDT_CFloat32;
+};
+
+template <>
+struct CXXTypeTraits<std::complex<double>>
+    : public detail::CXXTypeTraitsBase<std::complex<double>>
+{
+    static constexpr GDALDataType gdal_type = GDT_CFloat64;
+};
+
+#if defined(GDAL_ENABLE_FLOAT16) && defined(FLT16_MAX) && defined(FLT16_MIN)
+template <> struct CXXTypeTraits<_Float16>
+{
+    static constexpr GDALDataType gdal_type = GDT_Float16;
+};
+#endif
+
+template <>
+struct CXXTypeTraits<std::string>
+    : public detail::CXXTypeTraitsBase<std::string>
+{
+    static constexpr size_t size = 0;
+    static constexpr OGRFieldType ogr_type = OFTString;
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::CreateString();
+    }
+};
+
+//! @endcond
+
+/** Trait accepting a GDALDataType and mapping it to corresponding C++ type and
+ * OGRFieldType
+ *
+ * Each specialization has the following members:
+ * typedef T type; (except for GDT_CInt16 and GDT_CInt32)
+ * static constexpr size_t size;
+ * static constexpr OGRFieldType ogr_type;
+ * static constexpr OGRFieldSubType ogr_subtype;
+ * static inline GDALExtendedDataType GetExtendedDataType();
+ *
+ * @since 3.11
+ */
+template <GDALDataType T> struct GDALDataTypeTraits
+{
+};
+
+namespace detail
+{
+template <GDALDataType T> struct GDALDataTypeTraitsBase
+{
+
+    static constexpr size_t size = sizeof(typename GDALDataTypeTraits<T>::type);
+    static constexpr OGRFieldType ogr_type = GetOGRFieldType(T);
+    static constexpr OGRFieldSubType ogr_subtype = GetOGRFieldSubType(T);
+
+    static inline GDALExtendedDataType GetExtendedDataType()
+    {
+        return GDALExtendedDataType::Create(T);
+    }
+};
+}  // namespace detail
+
+//! @cond Doxygen_Suppress
+template <>
+struct GDALDataTypeTraits<GDT_Int8>
+    : public detail::GDALDataTypeTraitsBase<GDT_Int8>
+{
+    typedef int8_t type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_Byte>
+    : public detail::GDALDataTypeTraitsBase<GDT_Byte>
+{
+    typedef uint8_t type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_Int16>
+    : public detail::GDALDataTypeTraitsBase<GDT_Int16>
+{
+    typedef int16_t type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_UInt16>
+    : public detail::GDALDataTypeTraitsBase<GDT_UInt16>
+{
+    typedef uint16_t type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_Int32>
+    : public detail::GDALDataTypeTraitsBase<GDT_Int32>
+{
+    typedef int32_t type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_UInt32>
+    : public detail::GDALDataTypeTraitsBase<GDT_UInt32>
+{
+    typedef uint32_t type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_Int64>
+    : public detail::GDALDataTypeTraitsBase<GDT_Int64>
+{
+    typedef int64_t type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_UInt64>
+    : public detail::GDALDataTypeTraitsBase<GDT_UInt64>
+{
+    typedef uint64_t type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_Float32>
+    : public detail::GDALDataTypeTraitsBase<GDT_Float32>
+{
+    typedef float type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_Float64>
+    : public detail::GDALDataTypeTraitsBase<GDT_Float64>
+{
+    typedef double type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_CInt16>
+    : public detail::GDALDataTypeTraitsBase<GDT_CInt16>
+{
+    // typedef type not available !
+    static constexpr size_t size = sizeof(int16_t) * 2;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_CInt32>
+    : public detail::GDALDataTypeTraitsBase<GDT_CInt32>
+{
+    // typedef type not available !
+    static constexpr size_t size = sizeof(int32_t) * 2;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_CFloat32>
+    : public detail::GDALDataTypeTraitsBase<GDT_CFloat32>
+{
+    typedef std::complex<float> type;
+};
+
+template <>
+struct GDALDataTypeTraits<GDT_CFloat64>
+    : public detail::GDALDataTypeTraitsBase<GDT_CFloat64>
+{
+    typedef std::complex<double> type;
+};
+
+//! @endcond
 
 /** Map a GDALExtendedDataType to the most suitable OGRFieldType.
  *


### PR DESCRIPTION
Some ideas to remove boilerplate/duplicated information at the expense of some added complexity. For you to judge the tradeoffs.